### PR TITLE
Fix clock instance instancing it at bootstrap

### DIFF
--- a/App.go
+++ b/App.go
@@ -615,6 +615,7 @@ func NewApp(options *AppOptions) App {
 		router:        echo.New(),
 		routerGroups:  make(map[string]*echo.Group),
 		Resources:     make(map[string]*HTTPResource),
+		clock:         clock.New(),
 	}
 
 	app.RolesString, _ = acl.LoadRoles()


### PR DESCRIPTION
Fix clock instance instancing it at bootstrap to fix some errors with plugins needing it.